### PR TITLE
Adding Pagination and specs to the get loops api call

### DIFF
--- a/CHNAGELOG.md
+++ b/CHNAGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.0 ###
+* Added pagination to the `loops.all` call
+* Added specs to `rooms.all` as well
+
 ### 0.0.2 ###
 * Separated known errors into distinct error types including `Dothoop::UnauthorizedError` and `Dothoop::TooManyRequestsError`
 

--- a/lib/dothoop.rb
+++ b/lib/dothoop.rb
@@ -47,6 +47,8 @@ module Dothoop
   autoload :Referral, 'dothoop/models/referral'
   autoload :TaskList, 'dothoop/models/task_list'
 
+  autoload :MetaInformation, 'dothoop/models/meta_information'
+
   autoload :AccountResource, 'dothoop/resources/account_resource'
   autoload :ContactResource, 'dothoop/resources/contact_resource'
   autoload :LoopDetailResource, 'dothoop/resources/loop_detail_resource'
@@ -59,6 +61,7 @@ module Dothoop
   autoload :ProfileResource, 'dothoop/resources/profile_resource'
 
   autoload :ErrorHandlingResourcable, 'dothoop/error_handling_resourcable'
+  autoload :PaginatedResource, 'dothoop/paginated_resource'
 
   autoload :ErrorMapping, 'dothoop/mappings/error_mapping'
   Error = Class.new(StandardError)

--- a/lib/dothoop/models/meta_information.rb
+++ b/lib/dothoop/models/meta_information.rb
@@ -1,0 +1,17 @@
+module Dothoop
+  class MetaInformation < BaseModel
+    include Kartograph::DSL
+
+    kartograph do
+      mapping MetaInformation
+      root_key singular: 'meta', scopes: [:read]
+      
+      scoped :read do
+        property :total
+      end
+    end
+
+    attribute :total
+
+  end
+end

--- a/lib/dothoop/paginated_resource.rb
+++ b/lib/dothoop/paginated_resource.rb
@@ -1,0 +1,81 @@
+module Dothoop
+  class PaginatedResource
+    include Enumerable
+
+    BATCH_SIZE = 20
+
+    attr_reader :action, :resource, :collection
+    attr_accessor :total
+
+    def initialize(action, resource, *args)
+      @batch_number = 0
+      @total = nil
+      @action = action
+      @resource = resource
+      @collection = []
+      @args = args
+      @options = args.last.kind_of?(Hash) ? args.last : {}
+    end
+
+    def batch_size
+      @options[:batch_size] || BATCH_SIZE
+    end
+
+    def [](index)
+      @collection[index]
+    end
+
+    def each(start = 0)
+      # Start off with the first page if we have no idea of anything yet
+      fetch_next_page if total.nil?
+
+      return to_enum(:each, start) unless block_given?
+      Array(@collection[start..-1]).each do |element|
+        yield(element)
+      end
+
+      unless last?
+        start = [@collection.size, start].max
+        fetch_next_page
+        each(start, &Proc.new)
+      end
+
+      self
+    end
+
+    def last?
+      @batch_number == total_pages || self.total.zero?
+    end
+
+    def total_pages
+      return nil if self.total.nil?
+
+      (self.total.to_f / batch_size.to_f).ceil
+    end
+
+    def ==(other)
+      each_with_index.each.all? {|object, index| object == other[index] }
+    end
+
+    private
+
+    def fetch_next_page
+      @batch_number += 1
+      retrieve(@batch_number)
+    end
+
+    def retrieve(batch_number, batch_size = self.batch_size)
+      invoker = ResourceKit::ActionInvoker.new(action, resource, *@args)
+      invoker.options[:batch_size] ||= batch_size
+      invoker.options[:batch_number] = batch_number
+
+      @collection += invoker.handle_response
+
+      if total.nil?
+        meta = MetaInformation.extract_single(invoker.response.body, :read)
+        self.total = meta.total.to_i
+      end
+    end
+
+  end
+end

--- a/lib/dothoop/resources/loop_resource.rb
+++ b/lib/dothoop/resources/loop_resource.rb
@@ -35,7 +35,10 @@ module Dothoop
         handler(200) { |response| LoopMapping.extract_single(response.body, :read) }
       end
 
+    end
 
+    def all(*args)
+      PaginatedResource.new(action(:all), self, *args)
     end
 
   end

--- a/lib/dothoop/version.rb
+++ b/lib/dothoop/version.rb
@@ -1,3 +1,3 @@
 module Dothoop
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end

--- a/test/fixtures/loop/all_1.json
+++ b/test/fixtures/loop/all_1.json
@@ -1,0 +1,62 @@
+{
+  "meta": {
+    "total": 8
+  },
+  "data": [
+    {
+      "id": 34301,
+      "name": "4 Privet Drive, Little Whinging, Surrey, England, Great Britain",
+      "status": "SOLD",
+      "transactionType": "PURCHASE_OFFER",
+      "totalTaskCount": 5,
+      "completedTaskCount": 3,
+      "updated": "2017-05-30T21:42:17Z",
+      "created": "2017-05-17T01:18:37Z",
+      "loopUrl": "https://www.dootloop.com/m/loop?viewId=34301"
+    },
+    {
+      "id": 34302,
+      "name": "The Burrow, Ottery St Catchpole, Devon, West Country, England, Great Britain",
+      "status": "ARCHIVED",
+      "transactionType": "LISTING_FOR_SALE",
+      "totalTaskCount": 5,
+      "completedTaskCount": 3,
+      "updated": "2017-05-30T21:42:17Z",
+      "created": "2017-05-17T01:18:37Z",
+      "loopUrl": "https://www.dootloop.com/m/loop?viewId=34302"
+    },
+    {
+      "id": 34303,
+      "name": "Potter Cottage, Godric's Hollow, West Country, England, Great Britain",
+      "status": "UNDER_CONTRACT",
+      "transactionType": "LISTING_FOR_LEASE",
+      "totalTaskCount": 5,
+      "completedTaskCount": 3,
+      "updated": "2017-05-30T21:42:17Z",
+      "created": "2017-05-17T01:18:37Z",
+      "loopUrl": "https://www.dootloop.com/m/loop?viewId=34303"
+    },
+    {
+      "id": 34304,
+      "name": "12 Grimmauld Place, Islington, London, England",
+      "status": "LEASED",
+      "transactionType": "LEASE_OFFER",
+      "totalTaskCount": 5,
+      "completedTaskCount": 3,
+      "updated": "2017-05-30T21:42:17Z",
+      "created": "2017-05-17T01:18:37Z",
+      "loopUrl": "https://www.dootloop.com/m/loop?viewId=34304"
+    },
+    {
+      "id": 34305,
+      "name": "Shell Cottage, Outskirts of Tinworth, Cornwall, England",
+      "status": "DONE",
+      "transactionType": "REAL_ESTATE_OTHER",
+      "totalTaskCount": 5,
+      "completedTaskCount": 3,
+      "updated": "2017-05-30T21:42:17Z",
+      "created": "2017-05-17T01:18:37Z",
+      "loopUrl": "https://www.dootloop.com/m/loop?viewId=34305"
+    }
+  ]
+}

--- a/test/fixtures/loop/all_2.json
+++ b/test/fixtures/loop/all_2.json
@@ -1,0 +1,40 @@
+{
+  "meta": {
+    "total": 8
+  },
+  "data": [
+    {
+      "id": 34306,
+      "name": "Malfoy Manor, Wiltshire, England, Great Britain",
+      "status": "SOLD",
+      "transactionType": "PURCHASE_OFFER",
+      "totalTaskCount": 5,
+      "completedTaskCount": 3,
+      "updated": "2017-05-30T21:42:17Z",
+      "created": "2017-05-17T01:18:37Z",
+      "loopUrl": "https://www.dootloop.com/m/loop?viewId=34306"
+    },
+    {
+      "id": 34307,
+      "name": "Spinner's End, Cokeworth, Midlands, England, Great Britain",
+      "status": "ARCHIVED",
+      "transactionType": "LISTING_FOR_SALE",
+      "totalTaskCount": 5,
+      "completedTaskCount": 3,
+      "updated": "2017-05-30T21:42:17Z",
+      "created": "2017-05-17T01:18:37Z",
+      "loopUrl": "https://www.dootloop.com/m/loop?viewId=34307"
+    },
+    {
+      "id": 34308,
+      "name": "Shrieking Shack, Hogsmeade, Scotland, Great Britain",
+      "status": "UNDER_CONTRACT",
+      "transactionType": "LISTING_FOR_LEASE",
+      "totalTaskCount": 5,
+      "completedTaskCount": 3,
+      "updated": "2017-05-30T21:42:17Z",
+      "created": "2017-05-17T01:18:37Z",
+      "loopUrl": "https://www.dootloop.com/m/loop?viewId=34308"
+    }
+  ]
+}

--- a/test/lib/dothoop/resources/loop_resource_test.rb
+++ b/test/lib/dothoop/resources/loop_resource_test.rb
@@ -3,8 +3,36 @@ require 'test_helper'
 class Dothoop::LoopResourceTest < Minitest::Test
 
   class All < Minitest::Test
+
     def test_returns_an_array_of_loops
-      skip('Need to decided whether and what to test here')
+      stub_request(:get, "https://api-gateway.dotloop.com/public/v2/profile/42/loop").
+        with(query: {batch_number: 1, batch_size: 20}).
+        to_return(body: api_fixture('loop/all'))
+
+      connection = Dothoop::Client.new('access_token').connection
+      resource = Dothoop::LoopResource.new(connection: connection)
+      loops = resource.all(profile_id: 42)
+
+      assert_instance_of Dothoop::Loop, loops.first
+      assert_equal [34301, 34302, 34303, 34304, 34305], loops.map(&:id)
+      assert_equal 5, loops.map(&:id).size
+    end
+
+    def test_returns_an_array_of_loops_when_pagination_is_necessary
+      stub_request(:get, "https://api-gateway.dotloop.com/public/v2/profile/42/loop").
+        with(query: {batch_number: 1, batch_size: 5}).
+        to_return(body: api_fixture('loop/all_1'))
+      stub_request(:get, "https://api-gateway.dotloop.com/public/v2/profile/42/loop").
+        with(query: {batch_number: 2, batch_size: 5}).
+        to_return(body: api_fixture('loop/all_2'))
+
+      connection = Dothoop::Client.new('access_token').connection
+      resource = Dothoop::LoopResource.new(connection: connection)
+      loops = resource.all(profile_id: 42, batch_size: 5)
+
+      assert_instance_of Dothoop::Loop, loops.first
+      assert_equal [34301, 34302, 34303, 34304, 34305, 34306, 34307, 34308], loops.map(&:id)
+      assert_equal 8, loops.map(&:id).size
     end
   end
 


### PR DESCRIPTION
Added pagination to the `rooms.all` api call along with supporting spec, version, and changelog updates