### PR TITLE
Relax dependency on faraday

### DIFF
--- a/CHNAGELOG.md
+++ b/CHNAGELOG.md
@@ -1,3 +1,6 @@
+### 0.1.3 ###
+* Relax version dependency for Faraday
+
 ### 0.1.0 ###
 * Added pagination to the `loops.all` call
 * Added specs to `rooms.all` as well

--- a/dothoop.gemspec
+++ b/dothoop.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0.3'
   spec.add_dependency "resource_kit", '~> 0.1.5'
   spec.add_dependency "kartograph", '~> 0.2.3'
-  spec.add_dependency "faraday", '~> 0.9.1'
+  spec.add_dependency "faraday", '>= 0.9.1'
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/dothoop/version.rb
+++ b/lib/dothoop/version.rb
@@ -1,3 +1,3 @@
 module Dothoop
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
https://bostonlogic.atlassian.net/browse/BDT-7845

Relaxing Faraday version so we can upgrade other gems depending on Faraday being upgraded.